### PR TITLE
Fixed crash on android sdk < 24

### DIFF
--- a/src/main/kotlin/com/hosopy/actioncable/Connection.kt
+++ b/src/main/kotlin/com/hosopy/actioncable/Connection.kt
@@ -129,7 +129,7 @@ class Connection internal constructor(private val uri: URI, private val options:
 
         val requestBuilder = Request.Builder().url(urlBuilder.toString())
 
-        options.headers?.forEach { key, value -> requestBuilder.addHeader(key, value) }
+        options.headers?.forEach { (key, value) -> requestBuilder.addHeader(key, value) }
 
         val request = requestBuilder.build()
 


### PR DESCRIPTION
The code causes a `NoClassDefFoundError` on SDKs < 24, because of the absence of the method `Map.forEach`.
Detailed explanation of the error here: https://blog.danlew.net/2017/03/16/kotlin-puzzler-whose-line-is-it-anyways/
Applied the fix suggested in the article